### PR TITLE
Early stopping rounds

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -188,7 +188,7 @@ update!(bst, (X, y), num_round=10)
 To help prevent overfitting to the training set, it is helpful to use a validation set to evaluate against to ensure that the XGBoost iterations continue to generalise outside training loss reduction. Early stopping provides a convenient way to automatically stop the
 boosting process if it's observed that the generalisation capability of the model does not improve for `k` rounds.
 
-If there is more than one element in watchlist, by default the last element will be used. This makes it important to use an ordered data structure (OrderedDict) compared to a standard unordered dictionary; as you might not be guaranteed deterministic behaviour. There will be
+If there is more than one element in watchlist, by default the last element will be used. This makes it important to use an ordered data structure (`OrderedDict`) compared to a standard unordered dictionary; as you might not be guaranteed deterministic behaviour. There will be
 a warning if you want to execute early stopping mechanism (`early_stopping_rounds > 0`) but have provided a watchlist with type `Dict` with
 more than 1 element.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -188,6 +188,12 @@ update!(bst, (X, y), num_round=10)
 To help prevent overfitting to the training set, it is helpful to use a validation set to evaluate against to ensure that the XGBoost iterations continue to generalise outside training loss reduction. Early stopping provides a convenient way to automatically stop the
 boosting process if it's observed that the generalisation capability of the model does not improve for `k` rounds.
 
+If there is more than one element in watchlist, by default the last element will be used. This makes it important to use an ordered data structure (OrderedDict) compared to a standard unordered dictionary; as you might not be guaranteed deterministic behaviour. There will be
+a warning if you want to execute early stopping mechanism (`early_stopping_rounds > 0`) but have provided a watchlist with type `Dict` with
+more than 1 element.
+
+Similarly, if there is more than one element in eval_metric, by default the last element will be used.
+
 For example:
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -127,6 +127,7 @@ Unlike feature data, label data can be extracted after construction of the `DMat
 [`XGBoost.getlabel`](@ref).
 
 
+
 ## Booster
 The [`Booster`](@ref) object holds model data.  They are created with training data.  Internally
 this is always a `DMatrix` but arguments will be automatically converted.
@@ -181,4 +182,38 @@ is equivalent to
 ```julia
 bst = xgboost((X, y), num_round=10)
 update!(bst, (X, y), num_round=10)
+```
+
+### Early Stopping
+To help prevent overfitting to the training set, it is helpful to use a validation set to evaluate against to ensure that the XGBoost iterations continue to generalise outside training loss reduction. Early stopping provides a convenient way to automatically stop the
+boosting process if it's observed that the generalisation capability of the model does not improve for `k` rounds.
+
+For example:
+
+```julia
+using LinearAlgebra
+using OrderedCollections
+
+𝒻(x) = 2norm(x)^2 - norm(x)
+
+X = randn(100,3)
+y = 𝒻.(eachrow(X))
+
+dtrain = DMatrix((X, y))
+
+X_valid = randn(50,3)
+y_valid = 𝒻.(eachrow(X_valid))
+
+dvalid = DMatrix((X_valid, y_valid))
+
+bst = xgboost(dtrain, num_round = 100, eval_metric = "rmse", watchlist = OrderedDict(["train" => dtrain, "eval" => dvalid]), early_stopping_rounds = 5, max_depth=6, η=0.3)
+
+# get the best iteration and use it for prediction
+ŷ = predict(bst, X_valid, ntree_limit = bst.best_iteration)
+
+using Statistics
+println("RMSE from model prediction $(round((mean((ŷ - y_valid).^2).^0.5), digits = 8)).")
+
+# we can also retain / use the best score (based on eval_metric) which is stored in the booster
+println("Best RMSE from model training $(round((bst.best_score), digits = 8)).")
 ```

--- a/src/booster.jl
+++ b/src/booster.jl
@@ -440,7 +440,7 @@ function update!(b::Booster, data, a...;
 
     for j ∈ 1:num_round
         round_number = getnrounds(b) + 1
-        b, msg = updateone!(b, data, a...; round_number, kw...)
+        b, msg = updateone!(b, data, a...; round_number, watchlist, kw...)
         if !isempty(watchlist) && early_stopping_rounds > 0
             score, dataset, metric = extract_metric_value(msg)
             if (maximize && score > best_score || (!maximize && score < best_score))
@@ -495,7 +495,7 @@ function extract_metric_value(msg, dataset=nothing, metric=nothing)
     end
 
     if isnothing(metric)
-            # Find the first mentioned metric
+            # Find the last mentioned metric
             metrics = Set([m.match for m in eachmatch(r"(?<=-)\w+", msg)])
             metric = last(collect(metrics))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,13 +155,13 @@ end
         early_stopping_rounds = 2
         )
 
-        nrounds_bst = XGBoost.getnrounds(bst) 
-        nrounds_bst_early_stopping = XGBoost.getnrounds(bst_early_stopping) 
-        # Check to see that running with early stopping results in less than or equal rounds
-        @test nrounds_bst_early_stopping <= nrounds_bst
+    nrounds_bst = XGBoost.getnrounds(bst) 
+    nrounds_bst_early_stopping = XGBoost.getnrounds(bst_early_stopping) 
+    # Check to see that running with early stopping results in less than or equal rounds
+    @test nrounds_bst_early_stopping <= nrounds_bst
 
-        # Check number of rounds > early stopping rounds
-        @test nrounds_bst_early_stopping > 2
+    # Check number of rounds > early stopping rounds
+    @test nrounds_bst_early_stopping > 2
 
     # test the early stopping rounds interface with an OrderedDict data type in the watchlist
     watchlist_ordered = OrderedDict("train"=>dtrain, "eval"=>dtest)
@@ -228,8 +228,8 @@ end
         early_stopping_rounds = 2
         )
 
-        @test XGBoost.getnrounds(bst_early_stopping) > 2
-        @test XGBoost.getnrounds(bst_early_stopping) <= nrounds_bst
+    @test XGBoost.getnrounds(bst_early_stopping) > 2
+    @test XGBoost.getnrounds(bst_early_stopping) <= nrounds_bst
 
     # test the interface with an empty watchlist (no output)
     # this should trigger no early stopping rounds
@@ -241,8 +241,8 @@ end
         eval_metric=["rmsle","rmse"],
         early_stopping_rounds = 2  # this should be ignored
         )
-    
-        @test XGBoost.getnrounds(bst_empty_watchlist) == nrounds_bst
+
+    @test XGBoost.getnrounds(bst_empty_watchlist) == nrounds_bst
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,17 +244,6 @@ end
     
         @test XGBoost.getnrounds(bst_empty_watchlist) == nrounds_bst
 
-    # test the functionality of utilising the best model iteration
-    bst_early_stopping = xgboost(dtrain,
-        num_round=30,
-        η=1,
-        objective="binary:logistic",
-        eval_metric=["rmsle","rmse"],
-        early_stopping_rounds = 2
-        )
-
-   
-
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,8 +156,8 @@ end
 
         nrounds_bst = XGBoost.getnrounds(bst) 
         nrounds_bst_early_stopping = XGBoost.getnrounds(bst_early_stopping) 
-        # Check to see that running with early stopping results in less rounds
-        @test nrounds_bst_early_stopping < nrounds_bst
+        # Check to see that running with early stopping results in less than or equal rounds
+        @test nrounds_bst_early_stopping <= nrounds_bst
 
         # Check number of rounds > early stopping rounds
         @test nrounds_bst_early_stopping > 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using CUDA: has_cuda, cu
 import Term
 using Random, SparseArrays
 using Test
+using OrderedCollections
 
 include("utils.jl")
 


### PR DESCRIPTION
Made fixes to watchlist data structures and added functionality to capture best score / iteration for the predict() method.
Added additional test cases to increase test coverage for early stopping.